### PR TITLE
Fix typo calling `delay` function in `attempts` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ async function attempts(max, delayMs, func) {
         try {
             if (attempt != 0) {
                 core.warning(`Attempt ${attempt + 1} of #${max}. Delaying for ${delayMs}ms before start`)
-                await delayMs(delayMs)
+                await delay(delayMs)
             }
 
             await func()


### PR DESCRIPTION
This addresses the typo in the `attempts` function that is supposed to call `delay` and instead calls `delayMs` resulting in an error.